### PR TITLE
Bugfix: cybersource callback is not called.

### DIFF
--- a/sdk_ios_v2/CyberSource.swift
+++ b/sdk_ios_v2/CyberSource.swift
@@ -35,44 +35,26 @@ open class CyberSource: UIViewController, CyberSourceDelegate {
             }
             
             if let fraudDetectionConfig = fraudDetectionConfig {
-            
+                
                 self.profile =
                     TrustDefenderMobile(config: [
                         TDMOrgID: fraudDetectionConfig.orgId!,
-                        TDMDelegate: self,
                         TDMLocationServices: NSNumber(value: true)])
+                self.profile?.doProfileRequest(callback: { (response) in
+                    // call custom delegation when session id is created
+                    if let response = response {
+                        guard response["profile_status"] as! Int == 1 else {
+                            NSLog("There was an error trying to request profile.")
+                            return
+                        }
+                        
+                        self.delegate?.authFinished!(sessionId:response["session_id"] as! String )
+                    }
+                })
                 
-                self.profile?.doProfileRequest()
-            
             }
         }
-    }
-    
-    /*
-     Delegate implementation that call custom delegation when 
-     session id is created
-     
-     - parameter response: TrustDefender response
-     */
-    func profileComplete(_ response:[AnyHashable:Any]?) {
-        
-        if let response = response {
-            
-            guard response["profile_status"] as! Int == 1 else {
-                NSLog("There was an error trying to request profile.")
-                return
-            }
-            
-            self.delegate?.authFinished!(sessionId:response["session_id"] as! String )
-        }
-    }
-    
-    override open func viewDidLoad() {
-        super.viewDidLoad()
-    }
-    
-    override open func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
     }
 }
+
+

--- a/sdk_ios_v2/CyberSource.swift
+++ b/sdk_ios_v2/CyberSource.swift
@@ -11,7 +11,7 @@ import TrustDefenderMobile
  Delegate to ensure session id is created
  */
 @objc public protocol CyberSourceDelegate{
-    @objc optional func authFinished(sessionId:String)
+    @objc optional func authFinished(sessionId: String)
 }
 
 open class CyberSource: UIViewController, CyberSourceDelegate {
@@ -28,32 +28,40 @@ open class CyberSource: UIViewController, CyberSourceDelegate {
     open func auth(publicKey: String, isSandbox: Bool = false) {
         
         FraudDetectionAPI(publicKey: publicKey, isSandbox: isSandbox).getConfig { (fraudDetectionConfig, error) in
-            
             guard error == nil else {
-                NSLog("There was an error trying to get config")
-                return
+                return self.notifyErrorOnDelegate("Error on FraudDetectionAPI.getConfig")
             }
             
-            if let fraudDetectionConfig = fraudDetectionConfig {
-                
-                self.profile =
-                    TrustDefenderMobile(config: [
-                        TDMOrgID: fraudDetectionConfig.orgId!,
-                        TDMLocationServices: NSNumber(value: true)])
-                self.profile?.doProfileRequest(callback: { (response) in
-                    // call custom delegation when session id is created
-                    if let response = response {
-                        guard response["profile_status"] as! Int == 1 else {
-                            NSLog("There was an error trying to request profile.")
-                            return
-                        }
-                        
-                        self.delegate?.authFinished!(sessionId:response["session_id"] as! String )
-                    }
-                })
-                
+            guard let fraudDetectionConfig = fraudDetectionConfig else  {
+                return self.notifyErrorOnDelegate("No fraudDetectionConfig on FraudDetectionAPI.getConfig response")
             }
+            
+            self.profile = TrustDefenderMobile(config: [
+                    TDMOrgID: fraudDetectionConfig.orgId!,
+                    TDMLocationServices: NSNumber(value: true)])
+            
+            self.profile?.doProfileRequest(callback: { (response) in
+                // call custom delegation when session id is created
+                guard let response = response else {
+                    return self.notifyErrorOnDelegate("No response on TrustDefenderMobile.doProfileRequest")
+                }
+                
+                guard response["profile_status"] as! Int == 1 else {
+                    return self.notifyErrorOnDelegate("No profile_status on TrustDefenderMobile.doProfileRequest")
+                }
+                
+                guard let sessionId = response["session_id"] as? String else {
+                    return self.notifyErrorOnDelegate("No session_id on TrustDefenderMobile.doProfileRequest")
+                }
+                
+                self.delegate?.authFinished!(sessionId: sessionId)
+            })
         }
+    }
+    
+    private func notifyErrorOnDelegate(_ errorString: String) {
+        NSLog(errorString)
+        self.delegate?.authFinished!(sessionId: "")
     }
 }
 


### PR DESCRIPTION
- Changing profiling request from "method + delegate" to "method with callback block as parameter".
- Calling CyberSource.auth callback with empty string ("") as "sessionId" when CyberSource.auth fails.