### PR TITLE
Fix: Legacy Build System only

### DIFF
--- a/sdk_ios_v2.podspec
+++ b/sdk_ios_v2.podspec
@@ -34,4 +34,5 @@ s.library = 'z'
 s.ios.vendored_frameworks = 'TrustDefender.framework'
 s.source_files = 'sdk_ios_v2/**/*'
 s.dependency 'Alamofire', '~> 4.7'
+s.exclude_files = 'sdk_ios_v2/**/Info.plist'
 end


### PR DESCRIPTION
This solves the issue when you try to compile with the New Build System.

The file Info.plist should not be included in the pod installation.